### PR TITLE
add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,56 @@
+# Alpine Linux based dev container with build dependencies for 'cbmsrc' repository.
+# (See https://github.com/devcontainers/templates/tree/main/src/alpine)
+FROM mcr.microsoft.com/devcontainers/base:alpine
+
+# Install build dependencies for 'srecord'
+RUN apk add --no-cache \
+    boost-dev \
+    libtool \
+    libgcrypt-dev \
+    ghostscript \
+    groff
+
+# Build 'srecord' from source and install to '/usr/local/bin'
+RUN cd /tmp && \
+    wget https://sourceforge.net/projects/srecord/files/srecord/1.64/srecord-1.64.tar.gz && \
+    tar xf srecord-1.64.tar.gz && \
+    cd srecord-1.64 && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install && \
+    cd /tmp && \
+    rm -rf srecord-1.64*
+
+# Build 'kernalemu' from source and install to '/opt/kernalemu/bin'
+RUN cd /tmp && \
+    git clone https://github.com/mist64/kernalemu.git && \
+    cd kernalemu && \
+    make -j$(nproc) && \
+    mkdir -p /opt/kernalemu/bin && \
+    cp build/kernalemu /opt/kernalemu/bin && \
+    cd /tmp && \
+    rm -rf kernalemu
+
+# Set 'KERNALEMU' environment variable to the path of the 'kernalemu' binary
+ENV KERNALEMU=/opt/kernalemu/bin/kernalemu
+
+# Build 'cbm6502asm' from source and install to '/opt/cbm6502asm/bin'
+RUN cd /tmp && \
+    git clone https://github.com/mist64/cbm6502asm.git && \
+    cd cbm6502asm && \
+    make -j$(nproc) && \
+    mkdir -p /opt/cbm6502asm/bin && \
+    cp build/asm /opt/cbm6502asm/bin && \
+    cd /tmp && \
+    rm -rf cbm6502asm
+
+# Set 'CBM6502ASM' environment variable to the path of the 'cbm6502asm' binary
+ENV CBM6502ASM=/opt/cbm6502asm/bin/asm
+
+# Download 'assembler64.prg' from the 'kernalemu' repository and copy to '/opt/assembler64'
+RUN mkdir -p /opt/assembler64 && \
+    cd /opt/assembler64 && \
+    wget https://github.com/mist64/kernalemu/raw/refs/heads/main/demo/assembler64.prg
+
+# Set 'ASSEMBLER64' environment variable to the path of the 'assembler64.prg' file
+ENV ASSEMBLER64=/opt/assembler64/assembler64.prg

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+// Alpine Linux based dev container with build dependencies for 'cbmsrc' repository.
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "cbmsrc",
+	"build": {
+        "dockerfile": "Dockerfile"
+    }
+}


### PR DESCRIPTION
This PR adds an Alpine-based development container with all build dependencies and environment variables required by [build.sh](https://github.com/mist64/cbmsrc/blob/master/build.sh).

I set this up for my own development environment and thought it was worth sharing in case it saves someone else 20 minutes.

@mist64 - I'm assuming you're familiar with development containers, but I'm happy to provide more explanation.  I'll also understand if you're not interested in this PR.  Thanks for your work on maintaining this repo.  It's a fantastic resource!