### PR TITLE
remove mention of case-insensitive fs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository collects the *original* source code of various Commodore Business Machines (CBM) computers converted to a modern encoding (ASCII, LF, indentation).
 
-Using [kernalemu](https://github.com/mist64/kernalemu) and [cbm6502asm](https://github.com/mist64/cbm6502asm), almost all source in this repo can be built from the UNIX command line. To build everything, run `build.sh` from the Unix command line, on a case-insensitive filesystem. The script depends on the [srecord](https://srecord.sourceforge.net) package to convert the .hex files into binary.
+Using [kernalemu](https://github.com/mist64/kernalemu) and [cbm6502asm](https://github.com/mist64/cbm6502asm), almost all source in this repo can be built from the UNIX command line. To build everything, run `build.sh` from the Unix command line. The script depends on the [srecord](https://srecord.sourceforge.net) package to convert the .hex files into binary.
 
 ## KIM-1/AIM-65
 


### PR DESCRIPTION
Using a case-insensitive filesystem no longer appears to be a requirement (verified with ext4).

I'm guessing it was fixed by 'link_upper()', which was added in commit [0006b31](https://github.com/mist64/cbmsrc/commit/0006b311b7a5bf88e4bc8892c46f27f0d56ac350).
